### PR TITLE
Add bitaxe Gamma USB detection

### DIFF
--- a/docs/raspi3bplus-bitaxegamma-driver-tasks.md
+++ b/docs/raspi3bplus-bitaxegamma-driver-tasks.md
@@ -44,10 +44,10 @@ ESP-Miner をそのまま利用する場合は単体でマイニングが可能�
 - [ ] GPIO/SPI 接続の予備調査
 
 ### cgminer ドライバー実装
- - [x] ドライバー雛形 `driver-bitaxe.c` 作成
- - [x] `configure.ac` と `Makefile.am` 更新
+- [x] ドライバー雛形 `driver-bitaxe.c` 作成
+- [x] `configure.ac` と `Makefile.am` 更新
 - [ ] 初期化・ハッシュ処理の実装
-- [ ] `usbutils.c` へデバイス検出追加
+- [x] `usbutils.c` へデバイス検出追加
 
 ### テスト
 - [ ] Raspberry Pi でのビルド確認
@@ -57,4 +57,4 @@ ESP-Miner をそのまま利用する場合は単体でマイニングが可能�
 ### ドキュメント整備
 - [x] 設計書・仕様書・要件定義書作成
  - [x] ビルド手順と設定例の追記
-- [ ] ファームウェア書き込み手順作成
+- [x] ファームウェア書き込み手順作成

--- a/docs/raspi3bplus-bitaxegamma-flashing.md
+++ b/docs/raspi3bplus-bitaxegamma-flashing.md
@@ -1,0 +1,13 @@
+# bitaxe Gamma ファームウェア書き込み手順
+
+以下の手順は、USB ブリッジ用ファームウェアを ESP32 に書き込む際の一例です。`firmware/usb-bridge` ディレクトリでビルドしたバイナリを使用します。
+
+1. ESP32 を USB ケーブルで PC に接続し、ブートモードに入れます。
+2. [esptool.py](https://docs.espressif.com/projects/esptool/en/latest/) をインストールしていることを確認します。
+3. ビルド後に生成される `usb-bridge.bin` を 0x0 アドレスに書き込みます。
+
+```bash
+esptool.py --chip esp32 --baud 921600 write_flash 0x0 usb-bridge.bin
+```
+
+4. 書き込み完了後、ESP32 を再起動して cgminer からの接続を待ちます。

--- a/driver-bitaxe.c
+++ b/driver-bitaxe.c
@@ -5,11 +5,35 @@
 
 #include "config.h"
 #include "miner.h"
+#include "usbutils.h"
+
+struct bitaxe_info {
+        int dummy;
+};
+
+static struct cgpu_info *bitaxe_detect_one(struct libusb_device *dev,
+                                          struct usb_find_devices *found)
+{
+        struct cgpu_info *bitaxe = usb_alloc_cgpu(&bitaxe_drv, 1);
+
+        if (!usb_init(bitaxe, dev, found)) {
+                bitaxe = usb_free_cgpu(bitaxe);
+                return NULL;
+        }
+
+        bitaxe->device_data = cgcalloc(1, sizeof(struct bitaxe_info));
+        bitaxe->threads = 1;
+        add_cgpu(bitaxe);
+
+        applog(LOG_INFO, "%s: Found at %s", bitaxe->drv->dname,
+               bitaxe->device_path);
+
+        return bitaxe;
+}
 
 static void bitaxe_detect(bool __maybe_unused hotplug)
 {
-        /* Detection logic will be implemented later */
-        (void)hotplug;
+        usb_detect(&bitaxe_drv, bitaxe_detect_one);
 }
 
 struct device_drv bitaxe_drv = {

--- a/usbutils.c
+++ b/usbutils.c
@@ -78,6 +78,7 @@ static cgtimer_t usb11_cgt;
 #define HASHFAST_TIMEOUT_MS 999
 #define HASHRATIO_TIMEOUT_MS 999
 #define BLOCKERUPTER_TIMEOUT_MS 999
+#define BITAXE_TIMEOUT_MS 999
 
 /* The safety timeout we use, cancelling async transfers on windows that fail
  * to timeout on their own. */
@@ -97,6 +98,7 @@ static cgtimer_t usb11_cgt;
 #define HASHFAST_TIMEOUT_MS 500
 #define HASHRATIO_TIMEOUT_MS 200
 #define BLOCKERUPTER_TIMEOUT_MS 300
+#define BITAXE_TIMEOUT_MS 200
 #endif
 
 #define USB_EPS(_intx, _epinfosx) { \
@@ -198,7 +200,18 @@ static struct usb_epinfo bet_epinfos[] = {
 };
 
 static struct usb_intinfo bet_ints[] = {
-	USB_EPS(0, bet_epinfos)
+        USB_EPS(0, bet_epinfos)
+};
+#endif
+
+#ifdef USE_BITAXE
+static struct usb_epinfo baxg_epinfos[] = {
+        { LIBUSB_TRANSFER_TYPE_BULK,    64,     EPI(1), 0, 0 },
+        { LIBUSB_TRANSFER_TYPE_BULK,    64,     EPO(1), 0, 0 }
+};
+
+static struct usb_intinfo baxg_ints[] = {
+        USB_EPS(0, baxg_epinfos)
 };
 #endif
 
@@ -965,19 +978,31 @@ static struct usb_find_devices find_dev[] = {
 		INTINFO(ants3_ints) },
 #endif
 #ifdef USE_BLOCKERUPTER
-	{
-		.drv = DRIVER_blockerupter,
-		.name = "BET",
-		.ident = IDENT_BET,
-		.idVendor = 0x10c4,
-		.idProduct = 0xea60,
-		.config = 1,
-		.timeout = BLOCKERUPTER_TIMEOUT_MS,
-		.latency = LATENCY_UNUSED,
-		INTINFO(bet_ints) },
+        {
+                .drv = DRIVER_blockerupter,
+                .name = "BET",
+                .ident = IDENT_BET,
+                .idVendor = 0x10c4,
+                .idProduct = 0xea60,
+                .config = 1,
+                .timeout = BLOCKERUPTER_TIMEOUT_MS,
+                .latency = LATENCY_UNUSED,
+                INTINFO(bet_ints) },
 
 #endif
-	{ DRIVER_MAX, NULL, 0, 0, 0, NULL, NULL, 0, 0, 0, 0, NULL }
+#ifdef USE_BITAXE
+        {
+                .drv = DRIVER_bitaxe,
+                .name = "BAXG",
+                .ident = IDENT_BAXG,
+                .idVendor = 0x303a,
+                .idProduct = 0x1001,
+                .config = 1,
+                .timeout = BITAXE_TIMEOUT_MS,
+                .latency = LATENCY_UNUSED,
+                INTINFO(baxg_ints) },
+#endif
+        { DRIVER_MAX, NULL, 0, 0, 0, NULL, NULL, 0, 0, 0, 0, NULL }
 };
 
 #define STRBUFLEN 256

--- a/usbutils.h
+++ b/usbutils.h
@@ -176,9 +176,10 @@ enum sub_ident {
 	IDENT_KLN,
 	IDENT_LIN,
 	IDENT_LLT,
-	IDENT_MMQ,
-	IDENT_NFU,
-	IDENT_OSM
+        IDENT_MMQ,
+        IDENT_NFU,
+        IDENT_BAXG,
+        IDENT_OSM
 };
 
 struct usb_find_devices {


### PR DESCRIPTION
## Summary
- implement `bitaxe` driver detection logic
- define `IDENT_BAXG` and USB descriptor entries
- add endpoint information for bitaxe devices
- document flashing firmware for the usb bridge
- mark driver task progress

## Testing
- `./autogen.sh`
- `./configure --enable-bitaxe`
- `make -j$(nproc)`
- `(cd firmware/esp-miner && idf.py build)` *(fails: `idf.py` not found)*
- `(cd firmware/usb-bridge && idf.py build)` *(fails: `idf.py` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685266c2bfac8330b45b0ac04e6ad88c