### PR TITLE
Add ESP32 flashing environment steps

### DIFF
--- a/docs/raspi3bplus-bitaxegamma-flashing.md
+++ b/docs/raspi3bplus-bitaxegamma-flashing.md
@@ -2,6 +2,15 @@
 
 以下の手順は、USB ブリッジ用ファームウェアを ESP32 に書き込む際の一例です。`firmware/usb-bridge` ディレクトリでビルドしたバイナリを使用します。
 
+## 書き込み環境の準備
+
+ESP32 へファームウェアを書き込む PC には、以下のツールが導入されている必要があります。
+
+- Python 3.8 以降 と `pip`
+- `pip install --upgrade esptool` でインストールした **esptool**
+- ESP-IDF のセットアップ ( `idf.py` が実行できる状態 )
+- Linux の場合はシリアルポートへアクセスできる権限 (例: ユーザーを `dialout` グループに追加)
+
 1. ESP32 を USB ケーブルで PC に接続し、ブートモードに入れます。
 2. [esptool.py](https://docs.espressif.com/projects/esptool/en/latest/) をインストールしていることを確認します。
 3. ビルド後に生成される `usb-bridge.bin` を 0x0 アドレスに書き込みます。


### PR DESCRIPTION
## Summary
- include environment prerequisites for ESP32 firmware writing

## Testing
- `sh ./autogen.sh`
- `./configure --enable-bitaxe`
- `make -j"$(nproc)"`
- `(cd firmware/esp-miner && idf.py build)` *(fails: command not found)*
- `(cd firmware/usb-bridge && idf.py build)` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68526d3243a88330a2615468f419c206